### PR TITLE
set default batch_size to 16

### DIFF
--- a/cnn_benchmark.lua
+++ b/cnn_benchmark.lua
@@ -9,7 +9,7 @@ local cmd = torch.CmdLine()
 cmd:option('-model_t7', 'models/vgg16.t7')
 cmd:option('-image_height', 224)
 cmd:option('-image_width', 224)
-cmd:option('-batch_size', 32)
+cmd:option('-batch_size', 16)
 
 -- Benchmark options
 cmd:option('-num_passes', 10)


### PR DESCRIPTION
The benchmarks use 16 batch size. Make it default so the numbers from README are obtained by just setting the model argument (I was confused for a second why I get different numbers at first).
