### PR TITLE
Small improvements to python scripts

### DIFF
--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -7,15 +7,17 @@ parser.add_argument('--results_dir', default='outputs')
 parser.add_argument('--include_std', default=0)
 args = parser.parse_args()
 
-
 # Maps the cuDNN version reported by torch.cudnn to a more friendly string
-cudnn_map = {
-  5005: '5.0.05',
-  5105: '5.1.05',
-  5110: '5.1.10',
-  4007: '4.0.07',
-  'none': 'None',
-}
+def cudnn_name(version):
+  if version==None or version=='none':
+      return 'None'
+  if isinstance(version, str):
+      return version
+  # 5105 -> '5.1.05'
+  minor = version % 100
+  mid = version / 100 % 10
+  major = version / 1000
+  return '%d.%d.%02d' % (major, mid, minor)
 
 # Maps the GPU name reported by the driver to a more friendly string
 gpu_name_map = {
@@ -76,8 +78,7 @@ def main(args):
           if k not in keyed_results: continue
           result = keyed_results[k]
 
-          cudnn_str = cudnn_map[cudnn_version]
-          cudnn_str = cudnn_map.get(cudnn_version, cudnn_version)
+          cudnn_str = cudnn_name(cudnn_version)
           gpu_str = gpu_name_map.get(gpu_name, gpu_name)
 
           f_mean = mean(result['forward_times']) * 1000

--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--results_dir', default='outputs')
-parser.add_argument('--include_std', default=0)
+parser.add_argument('--include_std', default=0, action='store_const', const=1)
 args = parser.parse_args()
 
 # Maps the cuDNN version reported by torch.cudnn to a more friendly string

--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--results_dir', default='outputs')
-parser.add_argument('--include_std', default=0, action='store_const', const=1)
+parser.add_argument('--include_std', default=False, action='store_true')
 args = parser.parse_args()
 
 # Maps the cuDNN version reported by torch.cudnn to a more friendly string
@@ -88,7 +88,7 @@ def main(args):
           t_mean = mean(result['total_times']) * 1000
           t_std = std(result['total_times']) * 1000
 
-          if args.include_std == 1:
+          if args.include_std:
             f_str = '%7.2f += %4.2f' % (f_mean, f_std)
             b_str = '%7.2f += %4.2f' % (b_mean, b_std)
             t_str = '%7.2f += %4.2f' % (t_mean, t_std)

--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -89,14 +89,14 @@ def main(args):
           t_std = std(result['total_times']) * 1000
 
           if args.include_std == 1:
-            f_str = '% 6.2f += % 4.2f' % (f_mean, f_std)
-            b_str = '% 6.2f += % 4.2f' % (b_mean, b_std)
-            t_str = '% 6.2f += % 4.2f' % (t_mean, t_std)
+            f_str = '%7.2f += %4.2f' % (f_mean, f_std)
+            b_str = '%7.2f += %4.2f' % (b_mean, b_std)
+            t_str = '%7.2f += %4.2f' % (t_mean, t_std)
           else:
-            f_str = '% 6.2f' % f_mean
-            b_str = '% 6.2f' % b_mean
-            t_str = '% 6.2f' % t_mean
-          table_lines[t_mean] = '|%-25s|%-8s|%s|%s|%s|' % (
+            f_str = '%7.2f' % f_mean
+            b_str = '%7.2f' % b_mean
+            t_str = '%7.2f' % t_mean
+          table_lines[t_mean] = '|%-25s|%-7s|%s|%s|%s|' % (
                 gpu_str, cudnn_str, f_str, b_str, t_str)
 
       table_lines = [table_lines[k] for k in sorted(table_lines)]

--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -29,6 +29,20 @@ gpu_name_map = {
   'cpu': 'CPU: Dual Xeon E5-2630 v3',
 }
 
+# List defines order in which models will be printed
+# Matches order in README.md
+model_names_sorted = [
+  'alexnet',
+  'vgg16',
+  'vgg19',
+  'googlenet-v1',
+  'resnet-18',
+  'resnet-34',
+  'resnet-50',
+  'resnet-101',
+  'resnet-152',
+  'resnet-200'
+]
 
 def main(args):
   # Load all the results
@@ -65,9 +79,15 @@ def main(args):
     for v in vs:
       print '  %s' % v
   
-  markdown_tables = {}
+  markdown_tables = []
+
+  models = all_values['model']
+  # Sort loaded models to match README.md
+  sorted_models = [x for x in model_names_sorted if x in models]
+  # Append any remaining models that are not yet mentioned in README.md at the end
+  sorted_models += [x for x in models if x not in model_names_sorted]
   
-  for model in all_values['model']:
+  for model in sorted_models:
     for input_size in all_values['input_size']:
       table_header = '|GPU|cuDNN|Forward (ms)|Backward (ms)|Total (ms)|'
       table_header2 = '|---|---|---:|---:|---:|'
@@ -102,9 +122,9 @@ def main(args):
       table_lines = [table_lines[k] for k in sorted(table_lines)]
       table_lines = [table_header, table_header2] + table_lines
       model_batch_str = '%s (input %s)' % (model, input_size)
-      markdown_tables[model_batch_str] = table_lines
+      markdown_tables.append((model_batch_str, table_lines))
 
-  for model, table_lines in markdown_tables.iteritems():
+  for model, table_lines in markdown_tables:
     print model
     for line in table_lines:
       print line

--- a/analyze_cnn_benchmark_results.py
+++ b/analyze_cnn_benchmark_results.py
@@ -89,14 +89,14 @@ def main(args):
           t_std = std(result['total_times']) * 1000
 
           if args.include_std == 1:
-            f_str = '%.2f += %.2f' % (f_mean, f_std)
-            b_str = '%.2f += %.2f' % (b_mean, b_std)
-            t_str = '%.2f += %.2f' % (t_mean, t_std)
+            f_str = '% 6.2f += % 4.2f' % (f_mean, f_std)
+            b_str = '% 6.2f += % 4.2f' % (b_mean, b_std)
+            t_str = '% 6.2f += % 4.2f' % (t_mean, t_std)
           else:
-            f_str = '%.2f' % f_mean
-            b_str = '%.2f' % b_mean
-            t_str = '%.2f' % t_mean
-          table_lines[t_mean] = '|%s|%s|%s|%s|%s|' % (
+            f_str = '% 6.2f' % f_mean
+            b_str = '% 6.2f' % b_mean
+            t_str = '% 6.2f' % t_mean
+          table_lines[t_mean] = '|%-25s|%-8s|%s|%s|%s|' % (
                 gpu_str, cudnn_str, f_str, b_str, t_str)
 
       table_lines = [table_lines[k] for k in sorted(table_lines)]

--- a/run_cnn_benchmarks.py
+++ b/run_cnn_benchmarks.py
@@ -32,6 +32,12 @@ def main(args):
 
   base_command = 'th cnn_benchmark.lua'
 
+  try: 
+    os.makedirs(args.output_dir)
+  except OSError:
+    if not os.path.isdir(args.output_dir):
+      raise
+
   output_jsons = set()
   for vals in itertools.product(*factors.values()):
     lua_args = dict(zip(factors.keys(), vals))

--- a/run_cnn_benchmarks.py
+++ b/run_cnn_benchmarks.py
@@ -2,16 +2,16 @@ import os, json, itertools, random, argparse
 
 
 DEFAULT_MODELS = ','.join([
-  'models/alexnet/alexnet.t7',
-  'models/vgg16/vgg16.t7',
-  'models/vgg19/vgg19.t7',
-  'models/googlenet/googlenet-v1.t7',
-  'models/resnets/resnet-18.t7',
-  'models/resnets/resnet-34.t7',
-  'models/resnets/resnet-50.t7',
-  'models/resnets/resnet-101.t7',
-  'models/resnets/resnet-152.t7',
-  'models/resnets/resnet-200.t7',
+  'models/alexnet.t7',
+  'models/vgg16.t7',
+  'models/vgg19.t7',
+  'models/googlenet-v1.t7',
+  'models/resnet-18.t7',
+  'models/resnet-34.t7',
+  'models/resnet-50.t7',
+  'models/resnet-101.t7',
+  'models/resnet-152.t7',
+  'models/resnet-200.t7',
 ])
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Changes are aimed to reduce additional steps when benchmarking on a fresh setup and makes it easier to update **README.md** file.

1. Automatised cuDDN version conversion from int to a friendly string. Will automatically convert **5105** to **'5.1.05'**. Implemented as **_cudnn_name()_** function instead of **_cudnn_map_** dict.
2. Formatted printed out tables so that they are more readable in text format. That does not affect .md formatting since .md parser strips whitespace.
```
BEFORE:

|Maxwell Titan X|4.0.07|150.90|268.64|419.54|
|Pascal Titan X|None|238.04|371.40|609.43|
|GTX 1080 Ti|None|225.36|368.42|593.79|
|GTX 1080|None|299.05|461.67|760.72|
|Maxwell Titan X|None|382.39|583.83|966.22|
|CPU: Dual Xeon E5-2630 v3|None|6572.17|10300.61|16872.78|

NOW:

|Maxwell Titan X          |4.0.07 | 150.90| 268.64| 419.54|
|GTX 1080 Ti              |None   | 225.36| 368.42| 593.79|
|Pascal Titan X           |None   | 238.04| 371.40| 609.43|
|GTX 1080                 |None   | 299.05| 461.67| 760.72|
|Maxwell Titan X          |None   | 382.39| 583.83| 966.22|
|CPU: Dual Xeon E5-2630 v3|None   |6572.17|10300.61|16872.78|
```
3. Made order of printed out models to match order in README.md. Order is defined by _**model_names_sorted**_ array in **analyze_cnn_benchmark_results.py** file
3. Automatically create output directory, if missing.
4. Changed **_DEFAULT_MODELS_** to match file structure in **models.zip**